### PR TITLE
added kernel caching inside the GPU class

### DIFF
--- a/DataScience/DataScience.csproj
+++ b/DataScience/DataScience.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="ILGPU" Version="0.10.1" />
     <PackageReference Include="ILGPU.Algorithms" Version="0.10.0-beta1" />
+    <PackageReference Include="System.Runtime" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DataScience/GPU.cs
+++ b/DataScience/GPU.cs
@@ -1,9 +1,11 @@
 ﻿using ILGPU;
+using ILGPU.Algorithms;
 using ILGPU.IR.Transformations;
 using ILGPU.Runtime;
 using ILGPU.Runtime.CPU;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,6 +17,16 @@ namespace DataScience
         Context context;
         public Accelerator accelerator;
 
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, int> appendKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, float> nanToNumKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>, ArrayView<int>> accessSliceKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>, ArrayView<float>, SpecializedValue<int>> consecutiveOperationKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>, float, SpecializedValue<int>> scalarConsecutiveOperationKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>> diffKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>, ArrayView<float>> reverseKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>> absKernel;
+        public Action<AcceleratorStream, Index1, ArrayView<float>> inPlaceReciprocalKernel;
+
         public GPU(bool forceCPU = false, ContextFlags flags = ContextFlags.None, OptimizationLevel optimizationLevel = OptimizationLevel.Debug)
         {
             this.context = new Context(flags, optimizationLevel);
@@ -22,6 +34,28 @@ namespace DataScience
 
             this.accelerator = GetGpu(context, forceCPU);
             Console.WriteLine("Device loaded: " + accelerator.Name);
+
+            LoadKernels();
+            Console.WriteLine("Device Kernels Loaded");
+        }
+
+        private void LoadKernels()
+        {
+            Stopwatch timer = new Stopwatch();
+            timer.Start();
+
+            appendKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>, ArrayView<float>, int, int>(AppendKernel);
+            nanToNumKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, float>(Nan_to_numKernel);
+            accessSliceKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>, ArrayView<int>>(AccessSliceKernel);
+            consecutiveOperationKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>, ArrayView<float>, SpecializedValue<int>>(ConsecutiveOperationKernel);
+            scalarConsecutiveOperationKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>, float, SpecializedValue<int>>(ScalarConsecutiveOperationKernel);
+            diffKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>> (DiffKernel);
+            reverseKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>, ArrayView<float>> (ReverseKernel);
+            absKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>>(AbsKernel);
+            inPlaceReciprocalKernel = accelerator.LoadAutoGroupedKernel<Index1, ArrayView<float>>(InPlaceReciprocalKernel);
+
+            timer.Stop();
+            Console.WriteLine("Kernels Loaded in: " + timer.Elapsed.TotalMilliseconds + " MS");
         }
 
         private Accelerator GetGpu(Context context, bool prefCPU = false)
@@ -45,10 +79,114 @@ namespace DataScience
                 return Accelerator.Create(context, cl[0]);
             }
 
-
             //fallback
             Console.WriteLine("Warning : Could not find gpu, falling back to Default device");
             return new CPUAccelerator(context);
         }
+
+        //Kernels
+
+        static void AppendKernel(Index1 index, ArrayView<float> Output, ArrayView<float> vecA, ArrayView<float> vecB, int vecAcol, int vecBcol)
+        {
+            for (int i = 0; i < vecAcol; i++)
+            {
+                Output[index * (vecAcol + vecBcol) + i] = vecA[index * vecAcol + i];
+            }
+            for (int i = 0; i < vecBcol; i++)
+            {
+                Output[index * (vecAcol + vecBcol) + i + vecAcol] = vecB[index * vecBcol + i];
+            }
+        }
+
+        static void Nan_to_numKernel(Index1 index, ArrayView<float> IO, float num)
+        {
+            if (float.IsNaN(IO[index]) || float.IsInfinity(IO[index]))
+            {
+                IO[index] = num;
+            }
+
+        }
+
+        static void AccessSliceKernel(Index1 index, ArrayView<float> OutPut, ArrayView<float> Input, ArrayView<int> ChangeSelectLength)
+        {
+            OutPut[index] = Input[
+                index * ChangeSelectLength[0] * ChangeSelectLength[4] + // iRcL
+                index * ChangeSelectLength[1] +                         // iCc
+                ChangeSelectLength[2] * ChangeSelectLength[4] +         // RsL
+                ChangeSelectLength[3]];                                 // Cs
+        }
+
+        static void ConsecutiveOperationKernel(Index1 index, ArrayView<float> InputA, ArrayView<float> InputB, ArrayView<float> OutPut, SpecializedValue<int> operation)
+        {
+            switch ((ConsecutiveOperation)operation.Value)
+            {
+                case ConsecutiveOperation.multiplication:
+                    OutPut[index] = InputA[index] * InputB[index];
+                    break;
+                case ConsecutiveOperation.addition:
+                    OutPut[index] = InputA[index] + InputB[index];
+                    break;
+                case ConsecutiveOperation.subtraction:
+                    OutPut[index] = InputA[index] - InputB[index];
+                    break;
+                case ConsecutiveOperation.division:
+                    OutPut[index] = InputA[index] / InputB[index];
+                    break;
+                case ConsecutiveOperation.inverseDivision:
+                    OutPut[index] = InputB[index] / InputA[index];
+                    break;
+            }
+        }
+
+        static void ScalarConsecutiveOperationKernel(Index1 index, ArrayView<float> OutPut, ArrayView<float> Input, float Scalar, SpecializedValue<int> operation)
+        {
+            switch ((ConsecutiveOperation)operation.Value)
+            {
+                case ConsecutiveOperation.multiplication:
+                    OutPut[index] = Input[index] * Scalar;
+                    break;
+                case ConsecutiveOperation.addition:
+                    OutPut[index] = Input[index] + Scalar;
+                    break;
+                case ConsecutiveOperation.subtraction:
+                    OutPut[index] = Input[index] - Scalar;
+                    break;
+                case ConsecutiveOperation.division:
+                    OutPut[index] = Input[index] / Scalar;
+                    break;
+                case ConsecutiveOperation.inverseDivision:
+                    OutPut[index] = Scalar / Input[index];
+                    break;
+            }
+        }
+
+        static void DiffKernel(Index1 index, ArrayView<float> Output, ArrayView<float> Input)
+        {
+            Output[index] = Input[index + 1] - Input[index];
+        }
+
+        static void ReverseKernel(Index1 index, ArrayView<float> Output, ArrayView<float> Input)
+        {
+            Output[index] = Input[Input.Length - 1 - index];
+        }
+
+        static void AbsKernel(Index1 index, ArrayView<float> IO)
+        {
+            IO[index] = XMath.Abs(IO[index]);
+        }
+
+        static void InPlaceReciprocalKernel(Index1 index, ArrayView<float> IO)
+        {
+            IO[index] = XMath.Rcp(IO[index]);
+        }
+    }
+
+    public enum ConsecutiveOperation
+    {
+        multiplication = 0,
+        addition = 1,
+        subtraction = 2,
+        division = 3,
+        inverseDivision = 4,
     }
 }

--- a/Testing Console/Program.cs
+++ b/Testing Console/Program.cs
@@ -189,7 +189,7 @@ namespace Testing_Console
             }
             else
             {
-                Console.WriteLine("SubtractionTest Passed");
+                Console.WriteLine("SubtractionTest Failed");
             }
 
             Console.WriteLine("Construction Time: " + constructionTime.TotalMilliseconds + " ms");

--- a/Testing Console/Program.cs
+++ b/Testing Console/Program.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using DataScience;
-
-using ILGPU;
-using ILGPU.Runtime;
-using System.Linq;
-
+﻿using DataScience;
+using System;
 using System.Diagnostics;
 
 namespace Testing_Console
@@ -163,10 +158,42 @@ namespace Testing_Console
             //Console.Write(vectorB.ToCSV());
             //Console.WriteLine();
 
+            SubtractionTest(gpu, 10_000_000);
 
 
 
+        }
 
+        public static void SubtractionTest(GPU gpu, int size)
+        {
+            Stopwatch timer = Stopwatch.StartNew();
+
+            Vector a = Vector.Linspace(gpu, 0, 1, size, 1);
+            Vector b = Vector.Linspace(gpu, 1, 0, size, 1);
+
+            timer.Stop();
+            TimeSpan constructionTime = timer.Elapsed;
+            timer.Restart();
+
+            a._ConsecutiveOP(10, ConsecutiveOperation.multiplication);
+            b._ConsecutiveOP(10, ConsecutiveOperation.multiplication);
+
+            a._ConsecutiveOP(b, ConsecutiveOperation.subtraction);
+
+            timer.Stop();
+            TimeSpan calculationTime = timer.Elapsed;
+
+            if (a.Value[0] == 0)
+            {
+                Console.WriteLine("SubtractionTest Passed");
+            }
+            else
+            {
+                Console.WriteLine("SubtractionTest Passed");
+            }
+
+            Console.WriteLine("Construction Time: " + constructionTime.TotalMilliseconds + " ms");
+            Console.WriteLine("Calculation Time: " + calculationTime.TotalMilliseconds + " ms");
         }
     }
 }


### PR DESCRIPTION
I moved all the kernels into into the GPU class, and precompiled them after we get the accelerator. This moves around 400ms of latency away from the first kernel operation and into constructing the GPU.
![Screenshot 2021-05-11 233847](https://user-images.githubusercontent.com/13143533/117930388-c55c1080-b2b2-11eb-845a-5e4dac16b7fd.png)
![Screenshot 2021-05-11 233958](https://user-images.githubusercontent.com/13143533/117930376-c2f9b680-b2b2-11eb-99ba-2b6beea63a9a.png)

I also changed a few memory allocations to reduce garbage generation.

